### PR TITLE
Issue 1: Compilation errors

### DIFF
--- a/h264-decoder.hpp
+++ b/h264-decoder.hpp
@@ -25,7 +25,7 @@ public:
   auto decode(std::span<const uint8_t> data) -> const VFrame *;
 
 private:
-  struct AVCodec *codec;
+  const struct AVCodec *codec;
   struct AVCodecContext *ctx;
   struct AVFrame *yuvPicture;
   struct AVFrame *rgbPicture;


### PR DESCRIPTION
Issue #1: Fix two issues with compiling the plugin:

* Replace `avcodec_decode_video2()` with the new two-function sequence.
* Declare `H264Decoder::codec` as a `const` to match the variable passed to the constructor.