### PR TITLE
Fix macOS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 
 # The build artifact.
+/obs-airplay.dylib
 /obs-airplay.so
 
 # Tooling:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# Backup copies of files.
 *~
+
+# The build artifact.
 /obs-airplay.so
+
+# Tooling:
+# - build tool's state and intermediary build artifacts.
 /.coddle/
+# - cache files (e.g., clangd indexes)
+/.cache/
+# - Visual Studio Code editor configuration
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -36,3 +36,74 @@ I actually make a symbolic link in the `/usr/lib/x86_64-linux-gnu/obs-plugins/` 
 ```bash
 sudo ln -s /home/mika/prj/obs-airplay/obs-airplay.so /usr/lib/x86_64-linux-gnu/obs-plugins/obs-airplay.so
 ```
+
+### macOS
+
+#### Install dependencies
+
+```sh
+xcode-select --install
+brew install \
+    fdk-aac \
+    ffmpeg \
+    libplist \
+    openssl
+```
+
+#### Install the build tool
+
+If you do not already have [Coddle] installed:
+
+```sh
+git clone https://github.com/coddle-cpp/coddle.git
+cd coddle
+./build.sh
+sudo ./deploy.sh
+cd ..
+```
+
+[Coddle]: https://github.com/coddle-cpp/coddle
+
+#### Clone the OBS Studio source
+
+```sh
+# Change “30.2.3” to match your installed OBS version.
+git clone --branch 30.2.3 https://github.com/obsproject/obs-studio.git
+```
+
+This project's library configuration
+depends on the OBS source being located in an adjacent directory.
+If you want to put the OBS source tree elsewhere,
+you will need to update the `resources/macos/lib/obs` symlink accordingly.
+
+#### Clone the plugin
+
+```sh
+git clone --recurse-submodules https://github.com/mika314/obs-airplay.git
+```
+
+#### Build
+
+```sh
+cd obs-airplay
+coddle
+```
+
+#### Install the plugin
+
+On macOS, OBS plugins are [bundles].
+A template is available in the repo
+at `resources/macos/obs-airplay.plugin`.
+First, we'll copy that to somewhere OBS will find it;
+then we'll symlink our compiled plugin into it.
+
+```bash
+cp \
+    -R resources/macos/obs-airplay.plugin \
+    ~/Library/Application\ Support/obs-studio/plugins/
+ln -s \
+    $(realpath obs-airplay.dylib) \
+    ~/Library/Application\ Support/obs-studio/plugins/obs-airplay.plugin/Contents/MacOS/obs-airplay
+```
+
+[bundles]: https://en.wikipedia.org/wiki/Bundle_(macOS)

--- a/airplay.cpp
+++ b/airplay.cpp
@@ -61,7 +61,7 @@ static std::string find_mac()
 #else /* macOS and *BSD */
       if (ifaptr->ifa_addr->sa_family != AF_LINK)
         continue;
-      ptr = (unsigned char *)LLADDR((struct sockaddr_dl *)ifaptr->ifa_addr);
+      unsigned char *ptr = (unsigned char *)LLADDR((struct sockaddr_dl *)ifaptr->ifa_addr);
       for (int i = 0; i < 6; i++)
       {
         if ((octet[i] = *ptr) != 0)

--- a/coddle-macos.toml
+++ b/coddle-macos.toml
@@ -1,0 +1,3 @@
+cflags="-Iresources/macos/lib"
+# You will need to change this if OBS is not installed in its default location:
+ldflags="-F /Applications/OBS.app/Contents/Frameworks -framework libobs"

--- a/coddle-repo/libraries.toml
+++ b/coddle-repo/libraries.toml
@@ -1,9 +1,27 @@
 [[library]]
-type="file"
-name="uxplay"
-path="UxPlay/lib"
-includes=["raop.h"]
-incdir="../lib"
+type="pkgconfig"
+name="fdk-aac"
+includes=["fdk-aac/aacdecoder_lib.h"]
+
+[[library]]
+type="pkgconfig"
+name="libavcodec"
+includes=["libavcodec/avcodec.h"]
+
+[[library]]
+type="pkgconfig"
+name="libavutil"
+includes=["libavutil/avutil.h", "libavutil/imgutils.h", "libavutil/pixdesc.h"]
+
+[[library]]
+type="pkgconfig"
+name="libplist-2.0"
+includes=["plist/plist.h"]
+
+[[library]]
+type="pkgconfig"
+name="libswscale"
+includes=["libswscale/swscale.h"]
 
 [[library]]
 type="file"
@@ -12,7 +30,19 @@ path="UxPlay/lib/llhttp"
 includes=["llhttp/llhttp.h"]
 
 [[library]]
+type="pkgconfig"
+name="openssl"
+includes=["openssl/evp.h", "openssl/sha.h"]
+
+[[library]]
 type="file"
 name="playfair"
 path="UxPlay/lib/playfair"
 includes=["playfair/playfair.h"]
+[[library]]
+
+type="file"
+name="uxplay"
+path="UxPlay/lib"
+includes=["raop.h"]
+incdir="../lib"

--- a/coddle.toml
+++ b/coddle.toml
@@ -1,3 +1,3 @@
 shared=true
-ldflags="-ldns_sd -lplist"
+ldflags="-ldns_sd"
 localRepository="coddle-repo"

--- a/resources/macos/lib/obs
+++ b/resources/macos/lib/obs
@@ -1,0 +1,1 @@
+../../../../obs-studio/libobs

--- a/resources/macos/obs-airplay.plugin/Contents/Info.plist
+++ b/resources/macos/obs-airplay.plugin/Contents/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>obs-airplay</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.github.mika314.obsairplay</string>
+	<key>CFBundleVersion</key>
+	<string>0.0.0</string>
+	<key>CFBundleShortVersionString</key>
+	<string>0.0.0</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleExecutable</key>
+	<string>obs-airplay</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>14.0</string>
+</dict>
+</plist>


### PR DESCRIPTION
Thank you for your work on this project!

Because the include paths of Homebrew-managed libraries are not typically found in system include paths, I've reconfigured most libraries to use pkg-config. I was unable to do so for avahi-compat-libdns_sd, because that library only exists on Linux. Because the DNS-SD headers _should_ be installed in a default system search path on both macOS and Linux, the linker flag is sufficient.

Because the documentation assumes the use of the macOS standard `.dylib` file extension for dynamic shared libraries, this PR depends on https://github.com/coddle-cpp/coddle/pull/4.

Because macOS requires different linker flags to pull int the libobs framework distributed in the OBS application, this PR depends on https://github.com/coddle-cpp/coddle/pull/5.

Tested on macOS 14 and Arch Linux.