### PR TITLE
Update README.md (Install dependencies for macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ brew install \
     fdk-aac \
     ffmpeg \
     libplist \
-    openssl
+    openssl \
+    pkg-config
 ```
 
 #### Install the build tool


### PR DESCRIPTION
I am using Sequoia 15.3.1, the latest version at this moment. without brew package `pkg-config`, I couldn't build the obs-airplay. Please consider adding the package in this file.