### PR TITLE
This PR adds user-configurable options for the AirPlay server name and MAC address to improve compatibility and user experience

### DIFF
--- a/airplay.hpp
+++ b/airplay.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <stream.h>
 #include <vector>
+#include <string>
 
 class AirPlay
 {
@@ -13,6 +14,8 @@ public:
   auto getWidth() const -> int;
   auto getHeight() const -> int;
   auto name() const -> const char *;
+  auto update(struct obs_data *data) -> void;
+  auto apply_settings() -> void;
 
 private:
   auto render(const audio_decode_struct *data) -> void;
@@ -22,8 +25,9 @@ private:
                          unsigned short tcp[3],
                          unsigned short udp[3],
                          bool debug_log) -> int;
-
   auto stop_raop_server() -> int;
+  auto restart_server_with_settings(const std::string& name, bool use_random_mac) -> void;
+
   // Server callbacks
   static auto audio_flush(void *cls) -> void;
   static auto audio_get_format(void *cls,
@@ -62,4 +66,11 @@ private:
   int open_connections = 0;
   int width = 100;
   int height = 100;
+  
+  // Settings for dynamic AirPlay Server name
+  std::string current_server_name;
+  bool current_use_random_mac;
+  std::string pending_server_name;
+  bool pending_use_random_mac;
+  bool settings_changed;
 };

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -25,7 +25,7 @@ static auto sourceDestroy(void *v) -> void
 
 static auto sourceUpdate(void *v, obs_data_t *data) -> void
 {
-  LOG(__func__, v, data);
+  static_cast<AirPlay *>(v)->update(data);
 }
 
 static auto sourceWidth(void *v) -> uint32_t
@@ -38,6 +38,47 @@ static auto sourceHeight(void *v) -> uint32_t
   return static_cast<AirPlay *>(v)->getHeight();
 }
 
+static auto sourceGetDefaults(obs_data_t *data) -> void
+{
+  obs_data_set_default_string(data, "server_name", "OBS");
+  obs_data_set_default_bool(data, "use_random_mac", true);
+  obs_data_set_default_string(data, "mac_address_label", "Configure which MAC Address is being used.");
+  obs_data_set_default_string(data, "server_name_info", 
+    "Click 'Apply Server Name' to restart the AirPlay server with the new name, or restart OBS to apply changes automatically.");
+  obs_data_set_default_string(data, "random_mac_info", 
+    "When unchecked, the system's MAC address will be used. Random MAC is recommended to have iOS update the name immediately. iOS is caching the name very aggressively, only a some rare events like a timeout (restart of OBS with opened AirPlay Screensharing dialog) update the name.");
+}
+
+static bool apply_settings_clicked(obs_properties_t *props, obs_property_t *property, void *data)
+{
+  UNUSED_PARAMETER(props);
+  UNUSED_PARAMETER(property);
+  
+  AirPlay *airplay = static_cast<AirPlay *>(data);
+  if (airplay)
+  {
+    airplay->apply_settings();
+  }
+  return false; // Don't refresh properties
+}
+
+static auto sourceGetProperties(void *data) -> obs_properties_t *
+{
+  obs_properties_t *props = obs_properties_create();
+  
+  // Server Name section
+  obs_properties_add_text(props, "server_name", "Airplay Server Name", OBS_TEXT_DEFAULT);
+  obs_properties_add_button(props, "apply_name", "Apply Server Name", apply_settings_clicked);
+  obs_properties_add_text(props, "server_name_info", "", OBS_TEXT_INFO);
+  
+  // Random MAC Address section
+  obs_properties_add_text(props, "mac_address_label", "MAC Address Settings", OBS_TEXT_INFO);
+  obs_properties_add_bool(props, "use_random_mac", "Use Random MAC Address");
+  obs_properties_add_text(props, "random_mac_info", "", OBS_TEXT_INFO);
+  
+  return props;
+}
+
 static struct obs_source_info source = {.id = "AirPlay",
                                         .type = OBS_SOURCE_TYPE_INPUT,
                                         .output_flags = OBS_SOURCE_ASYNC_VIDEO | OBS_SOURCE_AUDIO,
@@ -47,6 +88,8 @@ static struct obs_source_info source = {.id = "AirPlay",
                                         .get_width = sourceWidth,
                                         .get_height = sourceHeight,
                                         .update = sourceUpdate,
+                                        .get_defaults = sourceGetDefaults,
+                                        .get_properties = sourceGetProperties,
                                         .icon_type = OBS_ICON_TYPE_DESKTOP_CAPTURE};
 
 bool obs_module_load(void)


### PR DESCRIPTION
## Changes Made
- Added server name input field with dedicated apply button
- Added random MAC address option (enabled by default)
- Added contextual help text for both options
- Implemented smart restart logic to prevent server restarts during typing of the server name
- Maintained backward compatibility

## Problems Solved
- **iOS Caching Issue**: iOS devices cache AirPlay servers by MAC address, causing that the changed name won't appear. Random MAC addresses resolve this.
- **User Experience**: Users can now customize the server name that appears on their devices

## Testing
- [x] Server name changes work correctly with apply button
- [x] Random MAC address option functions properly  
- [x] Settings persist correctly

## Screenshots
![image](https://github.com/user-attachments/assets/8b0a9eca-1781-43cb-85e8-b56b82a839af)

## Technical Details
- Server restarts only when MAC setting changes or Apply button is clicked
- Pending vs current settings tracking prevents unnecessary restarts
- Default random MAC addresses help new users avoid iOS connection issues