### PR TITLE
Fix audio frame buffer size

### DIFF
--- a/audio-decoder.hpp
+++ b/audio-decoder.hpp
@@ -24,5 +24,5 @@ public:
 private:
   struct AAC_DECODER_INSTANCE *decoder = nullptr;
   AFrame obsFrame;
-  std::array<int16_t, 8096> frame;
+  std::array<int16_t, 8192> frame;
 };


### PR DESCRIPTION
## Summary
- adjust `frame` array in `AudioDecoder` to hold 8192 elements

## Testing
- `g++ -std=c++20 -c audio-decoder.cpp` *(fails: `obs/obs.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f7a90faec832988842c3bf165a99e