### PR TITLE
Replace deprecated FFmpeg and sprintf calls

### DIFF
--- a/airplay.cpp
+++ b/airplay.cpp
@@ -75,7 +75,7 @@ static std::string find_mac()
         char str[3];
         for (int i = 0; i < 6; i++)
         {
-          sprintf(str, "%02x", octet[i]);
+          snprintf(str, sizeof(str), "%02x", octet[i]);
           mac = mac + str;
           if (i < 5)
             mac = mac + ":";

--- a/h264-decoder.cpp
+++ b/h264-decoder.cpp
@@ -29,13 +29,14 @@ H264Decoder::H264Decoder()
 
 H264Decoder::~H264Decoder()
 {
-  avcodec_close(ctx);
-  av_free(ctx);
-  av_free(yuvPicture);
-  av_free(rgbPicture);
-  av_free(pkt);
+  avcodec_free_context(&ctx);
+  av_frame_free(&yuvPicture);
+  av_frame_free(&rgbPicture);
+  av_packet_free(&pkt);
   if (swsContext)
     sws_freeContext(swsContext);
+  if (buffer)
+    av_free(buffer);
 }
 
 auto H264Decoder::decode(std::span<const uint8_t> data) -> const VFrame *


### PR DESCRIPTION
This PR replaces deprecated FFmpeg API calls with modern equivalents (avcodec_free_context, etc.) and replaces sprintf with snprintf for security.