### PR TITLE
Add dummy obsconfig.h to satisfy dependencies

### DIFF
--- a/resources/macos/lib/obsconfig.h
+++ b/resources/macos/lib/obsconfig.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#define OBS_DATA_PATH "data"
+#define OBS_PLUGIN_DESTINATION "obs-plugins"
+#define OBS_RELATIVE_PREFIX "../.."
+#define OBS_INSTALL_PREFIX ""
+#define OBS_RELEASE_CANDIDATE 0
+#define OBS_BETA 0


### PR DESCRIPTION
This PR adds a dummy obsconfig.h file to resources/macos/lib/ to satisfy the dependencies in the symlinked OBS headers.